### PR TITLE
feat: TheHeader 컴포넌트 추가

### DIFF
--- a/src/components/common/TheHeader.vue
+++ b/src/components/common/TheHeader.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="header">
+    <div class="header__title" @click="routeHome">
+      Gamenawa
+    </div>
+    <div class="header__search">
+      <BaseSearch/>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useRouter } from 'vue-router';
+import BaseSearch from '../base/BaseSearch.vue';
+
+const router = useRouter();
+
+function routeHome() {
+  router.push('/');
+}
+</script>
+
+<style lang="scss" scoped>
+.header {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+
+  height: 64px;
+
+  &__title {
+    font-size: 40px;
+    font-weight: 2000;
+    color: $color-primary;
+
+    cursor: pointer;
+  }
+
+  &__search {
+    margin-top: 10px;
+  }
+}
+</style>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,12 +1,12 @@
 <template>
   <div>
+    <TheHeader/>
     Welcome to Gamenawa!!
-    <BaseSearch/>
   </div>
 </template>
 
 <script setup lang="ts">
-import BaseSearch from '../components/base/BaseSearch.vue';
+import TheHeader from '../components/common/TheHeader.vue';
 </script>
 
 <style></style>

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -1,10 +1,13 @@
 <template>
     <div>
+      <TheHeader/>
         Search!!
     </div>
 </template>
 
 <script setup lang="ts">
+import TheHeader from '../components/common/TheHeader.vue';
+
 </script>
 
 <style>


### PR DESCRIPTION
## 상세 내용
- 타이틀(로고 대체)과 검색 컴포넌트 포함
- 타이틀을 누르면 home 뷰로 돌아옴
- 서치 시 해당 내용을 서치 뷰로 넘기는 기능은 넣지 않음 (아마 vuex로 하면 편할 듯?)

## 검증
로컬에서 작동을 확인함
- 홈 뷰
![image](https://user-images.githubusercontent.com/58730856/220280378-97f50503-34bb-4336-94f6-040b023b7de2.png)
- 서치 뷰
![image](https://user-images.githubusercontent.com/58730856/220280422-21e090ff-9ca6-47aa-a36a-c317d5aaae89.png)

